### PR TITLE
Separate live QCI tests from offline CI

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,6 +4,10 @@ channels = ["anaconda", "conda-forge"]
 python = ">=3.8,<=3.12"
 requests = ""
 
+[deps.libffi]
+version = ">=3.4,<3.5"
+channel = "anaconda"
+
 [pip.deps]
 qci-client = ">=4.5"
 numpy = ""

--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,6 +4,9 @@ channels = ["anaconda", "conda-forge"]
 python = ">=3.8,<=3.12"
 requests = ""
 
+# CondaPkg v0.2 does not support platform-scoped deps in this file.
+# Keep libffi aligned with the Anaconda Python build to avoid Windows
+# PythonCall _ctypes initialization failures.
 [deps.libffi]
 version = ">=3.4,<3.5"
 channel = "anaconda"

--- a/README.md
+++ b/README.md
@@ -66,6 +66,13 @@ $ julia
 julia> using QCIOpt
 ```
 
+Live QCI smoke tests are optional and require credentials. To run them locally, set
+`QCI_RUN_LIVE_TESTS=true` and `QCI_TOKEN`, then execute:
+
+```shell
+$ QCI_RUN_LIVE_TESTS=true QCI_TOKEN="your_token_here" julia --project=. -e 'using Pkg; Pkg.test()'
+```
+
 **Disclaimer:** _The QCI Optimization Wrapper for Julia is not officially supported by Quantum Computing Inc. If you are a commercial customer interested in official support for Julia from QCI, let them know!_
 
 **Note**: _If you are using [QCIOpt.jl](https://github.com/SECQUOIA/QCIOpt.jl) in your project, we recommend you to include the `.CondaPkg` entry in your `.gitignore` file. The `PythonCall` module will place a lot of files in this folder when building its Python environment._

--- a/src/QCIOpt.jl
+++ b/src/QCIOpt.jl
@@ -43,14 +43,18 @@ function __init__()
     return nothing
 end
 
-function __auth__()
+function __auth__(; verbose::Bool = false)
     qci_token = get(ENV, "QCI_TOKEN", nothing)
 
-    if isnothing(qci_token)
-        @warn """
-        Environment variable 'QCI_TOKEN' is not defined.
-        You can still provide it as an attribute to `QCIOpt.Optimizer` before calling `optimize!`
-        """
+    if isnothing(qci_token) || isempty(strip(qci_token))
+        QCI_TOKEN[] = nothing
+
+        if verbose
+            @warn """
+            Environment variable 'QCI_TOKEN' is not defined.
+            You can still provide it as an attribute to `QCIOpt.Optimizer` before calling `optimize!`
+            """
+        end
 
         return false
     else

--- a/test/auth.jl
+++ b/test/auth.jl
@@ -1,0 +1,19 @@
+@testset "Authentication" begin
+    for token in (nothing, "", " \t\n")
+        with_qci_token(token) do
+            @test !QCIOpt.__auth__()
+            @test QCIOpt.QCI_TOKEN[] === nothing
+        end
+    end
+
+    with_qci_token("test-token") do
+        @test QCIOpt.__auth__()
+        @test QCIOpt.QCI_TOKEN[] == "test-token"
+    end
+
+    code = "using QCIOpt; exit(QCIOpt.QCI_TOKEN[] === nothing ? 0 : 1)"
+    test_project = dirname(Base.active_project())
+    cmd = `$(Base.julia_cmd()) --project=$test_project -e $code`
+
+    @test success(addenv(cmd, "QCI_TOKEN" => ""))
+end

--- a/test/live_qci.jl
+++ b/test/live_qci.jl
@@ -1,0 +1,104 @@
+using Test
+using JuMP
+using QCIOpt
+
+if QCIOpt.__auth__()
+    @testset "Live QCI service smoke tests" begin
+        @testset "DIRAC-1 QUBO" begin
+            let model = Model(QCIOpt.Optimizer)
+                table = Dict(
+                    [0, 0] => 1,
+                    [0, 1] => 2,
+                    [1, 0] => 2,
+                    [1, 1] => 1,
+                )
+
+                @variable(model, x[1:2], Bin)
+
+                @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2])
+
+                set_attribute(model, QCIOpt.DeviceType(), "dirac-1")
+
+                optimize!(model)
+
+                @test result_count(model) >= 1
+
+                for i = 1:result_count(model)
+                    let xi = round.(Int, value.(x; result = i))
+                        @test length(xi) == 2
+                        @test objective_value(model; result = i) ≈ table[xi]
+                    end
+
+                    @test MOI.get(model, QCIOpt.ResultMultiplicity(i)) >= 1
+                end
+            end
+        end
+
+        @testset "DIRAC-3 QUBO" begin
+            let model = Model(QCIOpt.Optimizer)
+                table = Dict(
+                    [0, 0] => 1,
+                    [0, 1] => 2,
+                    [1, 0] => 2,
+                    [1, 1] => 1,
+                )
+
+                @variable(model, x[1:2], Bin)
+
+                @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2])
+
+                set_attribute(model, QCIOpt.DeviceType(), "dirac-3")
+
+                optimize!(model)
+
+                @test result_count(model) >= 1
+
+                for i = 1:result_count(model)
+                    let xi = round.(Int, value.(x; result = i))
+                        @test length(xi) == 2
+                        @test objective_value(model; result = i) ≈ table[xi]
+                    end
+
+                    @test MOI.get(model, QCIOpt.ResultMultiplicity(i)) >= 1
+                end
+            end
+        end
+
+        @testset "DIRAC-3 IP" begin
+            let model = Model(QCIOpt.Optimizer)
+                table = Dict(
+                    [-1, -1] => -3,
+                    [-1,  0] =>  0,
+                    [-1,  1] =>  3,
+                    [ 0, -1] =>  0,
+                    [ 0,  0] =>  1,
+                    [ 0,  1] =>  2,
+                    [ 1, -1] =>  3,
+                    [ 1,  0] =>  2,
+                    [ 1,  1] =>  1,
+                )
+
+                @variable(model, -1 <= x[1:2] <= 1, Int)
+
+                @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2])
+
+                set_attribute(model, QCIOpt.DeviceType(), "dirac-3")
+
+                optimize!(model)
+
+                @test result_count(model) >= 1
+
+                for i = 1:result_count(model)
+                    let xi = round.(Int, value.(x; result = i))
+                        @test length(xi) == 2
+                        @test objective_value(model; result = i) ≈ table[xi]
+                    end
+
+                    @test MOI.get(model, QCIOpt.ResultMultiplicity(i)) >= 1
+                end
+            end
+        end
+    end
+else
+    @info "Skipping live QCI service smoke tests because QCI_TOKEN is not set."
+end

--- a/test/offline.jl
+++ b/test/offline.jl
@@ -1,56 +1,60 @@
 @testset "Offline optimizer surface" begin
-    @test QCIOpt.qci_supported_devices() == ["dirac-1", "dirac-3"]
-    @test QCIOpt.qci_supports_device("dirac-1")
-    @test QCIOpt.qci_supports_device("dirac-3")
-    @test !QCIOpt.qci_supports_device("dirac-2")
-    @test QCIOpt.qci_device("dirac-1") isa QCIOpt.DIRAC_1
-    @test QCIOpt.qci_device("dirac-3") isa QCIOpt.DIRAC_3
+    with_qci_token(nothing) do
+        @test !QCIOpt.__auth__()
 
-    optimizer = QCIOpt.Optimizer()
+        @test QCIOpt.qci_supported_devices() == ["dirac-1", "dirac-3"]
+        @test QCIOpt.qci_supports_device("dirac-1")
+        @test QCIOpt.qci_supports_device("dirac-3")
+        @test !QCIOpt.qci_supports_device("dirac-2")
+        @test QCIOpt.qci_device("dirac-1") isa QCIOpt.DIRAC_1
+        @test QCIOpt.qci_device("dirac-3") isa QCIOpt.DIRAC_3
 
-    @test MOI.is_empty(optimizer)
-    @test MOI.supports(optimizer, QCIOpt.DeviceType())
-    @test MOI.supports(optimizer, MOI.Silent())
-    @test MOI.supports(optimizer, MOI.RawOptimizerAttribute("api_token"))
-    @test MOI.supports(optimizer, MOI.RawOptimizerAttribute("num_samples"))
-    @test MOI.get(optimizer, QCIOpt.DeviceType()) == "dirac-3"
-    @test MOI.get(optimizer, MOI.RawOptimizerAttribute("api_token")) === nothing
+        optimizer = QCIOpt.Optimizer()
 
-    MOI.set(optimizer, MOI.RawOptimizerAttribute("api_token"), "local-token")
-    @test MOI.get(optimizer, MOI.RawOptimizerAttribute("api_token")) == "local-token"
+        @test MOI.is_empty(optimizer)
+        @test MOI.supports(optimizer, QCIOpt.DeviceType())
+        @test MOI.supports(optimizer, MOI.Silent())
+        @test MOI.supports(optimizer, MOI.RawOptimizerAttribute("api_token"))
+        @test MOI.supports(optimizer, MOI.RawOptimizerAttribute("num_samples"))
+        @test MOI.get(optimizer, QCIOpt.DeviceType()) == "dirac-3"
+        @test MOI.get(optimizer, MOI.RawOptimizerAttribute("api_token")) === nothing
 
-    MOI.set(optimizer, MOI.Silent(), true)
-    @test MOI.get(optimizer, MOI.Silent())
+        MOI.set(optimizer, MOI.RawOptimizerAttribute("api_token"), "local-token")
+        @test MOI.get(optimizer, MOI.RawOptimizerAttribute("api_token")) == "local-token"
 
-    MOI.set(optimizer, QCIOpt.DeviceType(), "dirac-1")
-    @test MOI.get(optimizer, QCIOpt.DeviceType()) == "dirac-1"
-    @test MOI.get(optimizer, MOI.RawOptimizerAttribute("num_samples")) == 10
+        MOI.set(optimizer, MOI.Silent(), true)
+        @test MOI.get(optimizer, MOI.Silent())
 
-    model = Model(QCIOpt.Optimizer)
-    @variable(model, x[1:2], Bin)
-    @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2])
-    set_attribute(model, QCIOpt.DeviceType(), "dirac-1")
-    set_attribute(model, MOI.RawOptimizerAttribute("num_samples"), 5)
-    set_silent(model)
+        MOI.set(optimizer, QCIOpt.DeviceType(), "dirac-1")
+        @test MOI.get(optimizer, QCIOpt.DeviceType()) == "dirac-1"
+        @test MOI.get(optimizer, MOI.RawOptimizerAttribute("num_samples")) == 10
 
-    @test num_variables(model) == 2
+        model = Model(QCIOpt.Optimizer)
+        @variable(model, x[1:2], Bin)
+        @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2])
+        set_attribute(model, QCIOpt.DeviceType(), "dirac-1")
+        set_attribute(model, MOI.RawOptimizerAttribute("num_samples"), 5)
+        set_silent(model)
 
-    qubo_file = QCIOpt.qci_data_file([1.0 0.5; 0.5 2.0])
-    @test qubo_file["file_name"] == "smallest_objective.json"
-    @test haskey(qubo_file["file_config"], "qubo")
-    @test haskey(qubo_file["file_config"]["qubo"], "data")
+        @test num_variables(model) == 2
 
-    poly_file = QCIOpt.qci_data_file([[1, 0], [1, 2]], [1.5, -2.0])
-    poly = poly_file["file_config"]["polynomial"]
+        qubo_file = QCIOpt.qci_data_file([1.0 0.5; 0.5 2.0])
+        @test qubo_file["file_name"] == "smallest_objective.json"
+        @test haskey(qubo_file["file_config"], "qubo")
+        @test haskey(qubo_file["file_config"]["qubo"], "data")
 
-    @test poly_file["file_name"] == ""
-    @test poly["num_variables"] == 2
-    @test poly["min_degree"] == 1
-    @test poly["max_degree"] == 2
-    @test poly["data"] == [
-        Dict{String,Any}("idx" => [1, 0], "val" => 1.5),
-        Dict{String,Any}("idx" => [1, 2], "val" => -2.0),
-    ]
+        poly_file = QCIOpt.qci_data_file([[1, 0], [1, 2]], [1.5, -2.0])
+        poly = poly_file["file_config"]["polynomial"]
+
+        @test poly_file["file_name"] == ""
+        @test poly["num_variables"] == 2
+        @test poly["min_degree"] == 1
+        @test poly["max_degree"] == 2
+        @test poly["data"] == [
+            Dict{String,Any}("idx" => [1, 0], "val" => 1.5),
+            Dict{String,Any}("idx" => [1, 2], "val" => -2.0),
+        ]
+    end
 end
 
 @testset "Missing token optimize error" begin

--- a/test/offline.jl
+++ b/test/offline.jl
@@ -1,0 +1,74 @@
+@testset "Offline optimizer surface" begin
+    @test QCIOpt.qci_supported_devices() == ["dirac-1", "dirac-3"]
+    @test QCIOpt.qci_supports_device("dirac-1")
+    @test QCIOpt.qci_supports_device("dirac-3")
+    @test !QCIOpt.qci_supports_device("dirac-2")
+    @test QCIOpt.qci_device("dirac-1") isa QCIOpt.DIRAC_1
+    @test QCIOpt.qci_device("dirac-3") isa QCIOpt.DIRAC_3
+
+    optimizer = QCIOpt.Optimizer()
+
+    @test MOI.is_empty(optimizer)
+    @test MOI.supports(optimizer, QCIOpt.DeviceType())
+    @test MOI.supports(optimizer, MOI.Silent())
+    @test MOI.supports(optimizer, MOI.RawOptimizerAttribute("api_token"))
+    @test MOI.supports(optimizer, MOI.RawOptimizerAttribute("num_samples"))
+    @test MOI.get(optimizer, QCIOpt.DeviceType()) == "dirac-3"
+    @test MOI.get(optimizer, MOI.RawOptimizerAttribute("api_token")) === nothing
+
+    MOI.set(optimizer, MOI.RawOptimizerAttribute("api_token"), "local-token")
+    @test MOI.get(optimizer, MOI.RawOptimizerAttribute("api_token")) == "local-token"
+
+    MOI.set(optimizer, MOI.Silent(), true)
+    @test MOI.get(optimizer, MOI.Silent())
+
+    MOI.set(optimizer, QCIOpt.DeviceType(), "dirac-1")
+    @test MOI.get(optimizer, QCIOpt.DeviceType()) == "dirac-1"
+    @test MOI.get(optimizer, MOI.RawOptimizerAttribute("num_samples")) == 10
+
+    model = Model(QCIOpt.Optimizer)
+    @variable(model, x[1:2], Bin)
+    @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2])
+    set_attribute(model, QCIOpt.DeviceType(), "dirac-1")
+    set_attribute(model, MOI.RawOptimizerAttribute("num_samples"), 5)
+    set_silent(model)
+
+    @test num_variables(model) == 2
+
+    qubo_file = QCIOpt.qci_data_file([1.0 0.5; 0.5 2.0])
+    @test qubo_file["file_name"] == "smallest_objective.json"
+    @test haskey(qubo_file["file_config"], "qubo")
+    @test haskey(qubo_file["file_config"]["qubo"], "data")
+
+    poly_file = QCIOpt.qci_data_file([[1, 0], [1, 2]], [1.5, -2.0])
+    poly = poly_file["file_config"]["polynomial"]
+
+    @test poly_file["file_name"] == ""
+    @test poly["num_variables"] == 2
+    @test poly["min_degree"] == 1
+    @test poly["max_degree"] == 2
+    @test poly["data"] == [
+        Dict{String,Any}("idx" => [1, 0], "val" => 1.5),
+        Dict{String,Any}("idx" => [1, 2], "val" => -2.0),
+    ]
+end
+
+@testset "Missing token optimize error" begin
+    with_qci_token(nothing) do
+        @test !QCIOpt.__auth__()
+
+        model = Model(QCIOpt.Optimizer)
+        @variable(model, x[1:2], Bin)
+        @objective(model, Min, x[1] + x[2])
+
+        err = try
+            optimize!(model)
+            nothing
+        catch err
+            err
+        end
+
+        @test err isa ErrorException
+        @test occursin("QCI API Token is not defined.", sprint(showerror, err))
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -2,115 +2,14 @@ using Test
 using JuMP
 using QCIOpt
 
-function main()
-    @testset "QCIOpt Tests" begin
-        @testset "Authentication" begin
-            @test QCIOpt.__auth__()
-            
-            if QCIOpt.qci_is_free_tier()
-                @info "Running in QCI Free Tier"
-            end
-        end
+@testset "QCIOpt Tests" begin
+    include("test_utils.jl")
+    include("auth.jl")
+    include("offline.jl")
 
-        @testset "DIRAC-1 ■ QUBO" begin
-            let model = Model(QCIOpt.Optimizer)
-                table = Dict(
-                    [0, 0] => 1,
-                    [0, 1] => 2,
-                    [1, 0] => 2,
-                    [1, 1] => 1,
-                )
-
-                @variable(model, x[1:2], Bin)
-
-                @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2]) # x[1] ⊻ x[2]
-
-                set_attribute(model, QCIOpt.DeviceType(), "dirac-1")
-
-                optimize!(model)
-
-                @test result_count(model) >= 1
-
-                for i = 1:result_count(model)
-                    let xi = round.(Int, value.(x; result = i))
-                        @test length(xi) == 2
-                        @test objective_value(model; result = i) ≈ table[xi]
-                    end
-
-                    @test MOI.get(model, QCIOpt.ResultMultiplicity(i)) >= 1
-                end
-            end
-        end
-
-        @testset "DIRAC-3 ■ QUBO" begin
-            let model = Model(QCIOpt.Optimizer)
-                table = Dict(
-                    [0, 0] => 1,
-                    [0, 1] => 2,
-                    [1, 0] => 2,
-                    [1, 1] => 1,
-                )
-
-                @variable(model, x[1:2], Bin)
-
-                @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2]) # x[1] ⊻ x[2]
-
-                set_attribute(model, QCIOpt.DeviceType(), "dirac-3")
-
-                optimize!(model)
-
-                @test result_count(model) >= 1
-
-                for i = 1:result_count(model)
-                    let xi = round.(Int, value.(x; result = i))
-                        @test length(xi) == 2
-                        @test objective_value(model; result = i) ≈ table[xi]
-                    end
-
-                    @test MOI.get(model, QCIOpt.ResultMultiplicity(i)) >= 1
-                end
-            end
-        end
-
-        @testset "DIRAC-3 ■ IP" begin
-            let model = Model(QCIOpt.Optimizer)
-                table = Dict(
-                    [-1, -1] => -3,
-                    [-1,  0] =>  0,
-                    [-1,  1] =>  3,
-                    [ 0, -1] =>  0,
-                    [ 0,  0] =>  1,
-                    [ 0,  1] =>  2,
-                    [ 1, -1] =>  3,
-                    [ 1,  0] =>  2,
-                    [ 1,  1] =>  1,
-                )
-
-                @variable(model, -1 <= x[1:2] <= 1, Int)
-
-                @objective(model, Min, 1 + x[1] + x[2] - 2 * x[1] * x[2])
-
-                set_attribute(model, QCIOpt.DeviceType(), "dirac-3")
-
-                # set_silent(model)
-
-                optimize!(model)
-
-                @test result_count(model) >= 1
-
-                for i = 1:result_count(model)
-                    let xi = round.(Int, value.(x; result = i))
-                        @test length(xi) == 2
-                        @test objective_value(model; result = i) ≈ table[xi]
-                    end
-
-                    @test MOI.get(model, QCIOpt.ResultMultiplicity(i)) >= 1
-                end
-            end
-        end
+    if lowercase(get(ENV, "QCI_RUN_LIVE_TESTS", "false")) in ("1", "true", "yes")
+        include("live_qci.jl")
+    else
+        @info "Skipping live QCI service smoke tests. Set QCI_RUN_LIVE_TESTS=true and QCI_TOKEN to enable them."
     end
-
-    return nothing
 end
-
-main() # Here we go!

--- a/test/test_utils.jl
+++ b/test/test_utils.jl
@@ -1,0 +1,25 @@
+function with_qci_token(f::Function, value)
+    had_token = haskey(ENV, "QCI_TOKEN")
+    old_env = get(ENV, "QCI_TOKEN", "")
+    old_ref = QCIOpt.QCI_TOKEN[]
+
+    try
+        if isnothing(value)
+            delete!(ENV, "QCI_TOKEN")
+        else
+            ENV["QCI_TOKEN"] = value
+        end
+
+        QCIOpt.QCI_TOKEN[] = "stale-token"
+
+        return f()
+    finally
+        if had_token
+            ENV["QCI_TOKEN"] = old_env
+        else
+            delete!(ENV, "QCI_TOKEN")
+        end
+
+        QCIOpt.QCI_TOKEN[] = old_ref
+    end
+end


### PR DESCRIPTION
## Summary

- Treat missing, empty, and whitespace-only `QCI_TOKEN` as unauthenticated and clear the cached token.
- Split always-on tests into auth/offline coverage, with live QCI smoke tests moved to `test/live_qci.jl`.
- Gate live smoke tests behind `QCI_RUN_LIVE_TESTS=true` and document the credentialed command.
- Add offline coverage for package initialization without credentials, device lookup, optimizer/model construction, attributes, QCI data-file construction, and the missing-token optimize error.

## Tests

- `julia --project=test --compiled-modules=no -e 'using Pkg; Pkg.develop(path=pwd()); include("test/runtests.jl")'` - passed: 38 tests, live QCI tests skipped because `QCI_TOKEN` was not set.
- `git diff --check` - passed.

## Notes

- `julia --project=. -e 'using Pkg; Pkg.test()'` was attempted, but local Julia 1.10.11 crashed in `lld` while compiling JuMP before tests ran.
- Retrying `Pkg.test()` with compiled modules disabled got past that linker issue, but the temporary CondaPkg environment failed to create because `/tmp` was full.
- Live QCI smoke tests were not run because credentials are not available in this environment.

Closes #9
