### PR TITLE
Modernize GitHub Actions pins

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,6 @@
+version: 2
+updates:
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "monthly"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,11 +26,12 @@ jobs:
             os: windows-latest
             arch: x64
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@v1
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
+      - uses: julia-actions/cache@v3
       - uses: julia-actions/julia-buildpkg@v1
       - uses: julia-actions/julia-runtest@v1
         env:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -10,15 +10,15 @@ jobs:
   build:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
-      - uses: julia-actions/setup-julia@latest
+      - uses: actions/checkout@v6
+      - uses: julia-actions/setup-julia@v3
         with:
           version: '1.10'
       - name: Develop DocumenterDiagrams.jl
         run: julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd())'
-      - uses: julia-actions/julia-buildpkg@latest
-        with: 
-            project: "docs"
+      - uses: julia-actions/julia-buildpkg@v1
+        with:
+          project: "docs"
       - name: Build and deploy
         env:
           QCI_TOKEN: ${{ secrets.QCI_TOKEN }}  # For authentication with QCI 

--- a/.github/workflows/docscleanup.yml
+++ b/.github/workflows/docscleanup.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout gh-pages branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v6
         with:
           ref: gh-pages
 

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -15,10 +15,13 @@ import Pkg
     @test !compat_allows_julia_110(Dict("LinearAlgebra" => "1.11.0"), "LinearAlgebra")
 
     workflow_dir = joinpath(@__DIR__, "..", ".github", "workflows")
-    ci = read(joinpath(workflow_dir, "ci.yml"), String)
-    docs = read(joinpath(workflow_dir, "docs.yml"), String)
-    docscleanup = read(joinpath(workflow_dir, "docscleanup.yml"), String)
-    all_workflows = join([ci, docs, docscleanup], "\n")
+    workflow_files =
+        filter(file -> endswith(file, ".yml") || endswith(file, ".yaml"), readdir(workflow_dir))
+    workflow_texts = Dict(file => read(joinpath(workflow_dir, file), String) for file in workflow_files)
+    ci = workflow_texts["ci.yml"]
+    docs = workflow_texts["docs.yml"]
+    docscleanup = workflow_texts["docscleanup.yml"]
+    all_workflows = join((workflow_texts[file] for file in workflow_files), "\n")
 
     function has_ci_matrix_entry(version, os)
         escaped_version = replace(version, "." => "\\.")

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -14,7 +14,11 @@ import Pkg
     @test compat_allows_julia_110(Dict("LinearAlgebra" => "1"), "LinearAlgebra")
     @test !compat_allows_julia_110(Dict("LinearAlgebra" => "1.11.0"), "LinearAlgebra")
 
-    ci = read(joinpath(@__DIR__, "..", ".github", "workflows", "ci.yml"), String)
+    workflow_dir = joinpath(@__DIR__, "..", ".github", "workflows")
+    ci = read(joinpath(workflow_dir, "ci.yml"), String)
+    docs = read(joinpath(workflow_dir, "docs.yml"), String)
+    docscleanup = read(joinpath(workflow_dir, "docscleanup.yml"), String)
+    all_workflows = join([ci, docs, docscleanup], "\n")
 
     function has_ci_matrix_entry(version, os)
         escaped_version = replace(version, "." => "\\.")
@@ -26,4 +30,22 @@ import Pkg
     @test has_ci_matrix_entry("1", "ubuntu-latest")
     @test has_ci_matrix_entry("1.10", "windows-latest")
     @test has_ci_matrix_entry("1", "windows-latest")
+
+    @test occursin("uses: actions/checkout@v6", ci)
+    @test occursin("uses: julia-actions/setup-julia@v3", ci)
+    @test occursin("uses: julia-actions/cache@v3", ci)
+    @test occursin("uses: julia-actions/julia-buildpkg@v1", ci)
+    @test occursin("uses: julia-actions/julia-runtest@v1", ci)
+    @test occursin("uses: actions/checkout@v6", docs)
+    @test occursin("uses: julia-actions/setup-julia@v3", docs)
+    @test occursin("uses: julia-actions/julia-buildpkg@v1", docs)
+    @test occursin("uses: actions/checkout@v6", docscleanup)
+    @test !occursin("@latest", all_workflows)
+    @test !occursin("actions/checkout@v2", all_workflows)
+    @test !occursin("julia-actions/setup-julia@v1", all_workflows)
+
+    dependabot = read(joinpath(@__DIR__, "..", ".github", "dependabot.yml"), String)
+    @test occursin(r"package-ecosystem:\s*[\"']?github-actions[\"']?", dependabot)
+    @test occursin(r"directory:\s*[\"']?/[\"']?", dependabot)
+    @test occursin(r"interval:\s*[\"']?monthly[\"']?", dependabot)
 end


### PR DESCRIPTION
## Summary

- Update CI, docs, and docs cleanup workflow action refs to pinned current majors.
- Add `julia-actions/cache@v3` to the CI workflow while keeping the existing Julia and OS matrix behavior.
- Add monthly Dependabot updates for `github-actions`.
- Extend the metadata regression test to cover workflow action pins, absence of floating `@latest` refs, and the Dependabot policy.

## Tests

- `julia --project=test --compiled-modules=no -e 'using Test; include("test/compat_metadata.jl")'` - passed: 24 tests.
- `julia --project=test --compiled-modules=no -e 'using Pkg; Pkg.develop(path=pwd()); include("test/runtests.jl")'` - passed: 63 tests; live QCI tests skipped because `QCI_RUN_LIVE_TESTS` was not enabled.
- `julia --project=. --compiled-modules=no -e 'using Pkg; Pkg.test()'` - passed: 63 tests; live QCI tests skipped because `QCI_RUN_LIVE_TESTS` was not enabled.
- `git diff --check` - passed.

Closes #6
