### PR TITLE
Make docs deploy Dependabot-safe

### DIFF
--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -19,8 +19,11 @@ jobs:
       - uses: julia-actions/julia-buildpkg@v1
         with:
           project: "docs"
-      - name: Build and deploy
+      - name: Build docs
+        if: github.event_name == 'pull_request'
+        run: julia --project=docs docs/make.jl
+      - name: Build and deploy docs
+        if: github.event_name != 'pull_request'
         env:
-          QCI_TOKEN: ${{ secrets.QCI_TOKEN }}  # For authentication with QCI 
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }} # For authentication with GitHub Actions token
         run: julia --project=docs docs/make.jl --deploy

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -29,6 +29,11 @@ import Pkg
         return occursin(pattern, ci)
     end
 
+    function workflow_step(text, name)
+        step = match(Regex("(?ms)^\\s*- name: " * name * "\\s*\\n(.*?)(?=^\\s*- name: |\\z)"), text)
+        return isnothing(step) ? "" : step.match
+    end
+
     @test has_ci_matrix_entry("1.10", "ubuntu-latest")
     @test has_ci_matrix_entry("1", "ubuntu-latest")
     @test has_ci_matrix_entry("1.10", "windows-latest")
@@ -46,6 +51,19 @@ import Pkg
     @test !occursin("@latest", all_workflows)
     @test !occursin("actions/checkout@v2", all_workflows)
     @test !occursin("julia-actions/setup-julia@v1", all_workflows)
+
+    docs_build_step = workflow_step(docs, "Build docs")
+    docs_deploy_step = workflow_step(docs, "Build and deploy docs")
+    @test !isempty(docs_build_step)
+    @test occursin("if: github.event_name == 'pull_request'", docs_build_step)
+    @test occursin(r"(?m)^\s*run:\s*julia --project=docs docs/make\.jl\s*$", docs_build_step)
+    @test !occursin("--deploy", docs_build_step)
+    @test !occursin("QCI_TOKEN", docs_build_step)
+    @test !isempty(docs_deploy_step)
+    @test occursin("if: github.event_name != 'pull_request'", docs_deploy_step)
+    @test occursin(r"(?m)^\s*run:\s*julia --project=docs docs/make\.jl --deploy\s*$", docs_deploy_step)
+    @test occursin("GITHUB_TOKEN", docs_deploy_step)
+    @test !occursin("QCI_TOKEN", docs)
 
     dependabot = read(joinpath(@__DIR__, "..", ".github", "dependabot.yml"), String)
     @test occursin(r"package-ecosystem:\s*[\"']?github-actions[\"']?", dependabot)


### PR DESCRIPTION
## Summary

- Split the docs workflow into a pull-request build step without deployment and a trusted-event deploy step.
- Remove `QCI_TOKEN` from docs workflow execution so docs builds do not require live QCI credentials.
- Extend metadata tests to assert pull-request docs builds do not use `--deploy` and deploys stay limited to non-PR events.

## Tests

- `julia --project=test --compiled-modules=no -e 'using Test; include("test/compat_metadata.jl")'` - passed: 34 tests.
- `julia --project=docs --compiled-modules=no -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'` - passed.
- `julia --project=docs --compiled-modules=no docs/make.jl` - passed without `QCI_TOKEN`; Documenter emitted existing documentation warnings and skipped deployment.
- `julia --project=test --compiled-modules=no -e 'using Pkg; Pkg.develop(path=pwd()); include("test/runtests.jl")'` - passed: 73 tests; live QCI tests skipped because `QCI_RUN_LIVE_TESTS` was not enabled.
- `julia --project=. --compiled-modules=no -e 'using Pkg; Pkg.test()'` - passed: 73 tests; live QCI tests skipped because `QCI_RUN_LIVE_TESTS` was not enabled.
- `git diff --check` - passed.

Closes #8
