### PR TITLE
Tolerate missing docs preview cleanup paths

### DIFF
--- a/.github/workflows/docscleanup.yml
+++ b/.github/workflows/docscleanup.yml
@@ -14,16 +14,24 @@ jobs:
           ref: gh-pages
 
       - name: Delete preview and history
+        id: cleanup
         run: |
             git config user.name  "Documenter.jl"
             git config user.email "documenter@juliadocs.github.io"
+            if [ ! -d "previews/PR$PRNUM" ]; then
+                echo "No preview directory found for PR$PRNUM"
+                echo "deleted=false" >> "$GITHUB_OUTPUT"
+                exit 0
+            fi
             git rm -rf "previews/PR$PRNUM"
             git commit -m "delete preview"
             git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+            echo "deleted=true" >> "$GITHUB_OUTPUT"
         env:
             PRNUM: ${{ github.event.number }}
 
       - name: Push changes
+        if: steps.cleanup.outputs.deleted == 'true'
         run: |
             git push --force origin gh-pages-new:gh-pages
 

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -54,6 +54,8 @@ import Pkg
 
     docs_build_step = workflow_step(docs, "Build docs")
     docs_deploy_step = workflow_step(docs, "Build and deploy docs")
+    docs_cleanup_delete_step = workflow_step(docscleanup, "Delete preview and history")
+    docs_cleanup_push_step = workflow_step(docscleanup, "Push changes")
     @test !isempty(docs_build_step)
     @test occursin("if: github.event_name == 'pull_request'", docs_build_step)
     @test occursin(r"(?m)^\s*run:\s*julia --project=docs docs/make\.jl\s*$", docs_build_step)
@@ -64,6 +66,13 @@ import Pkg
     @test occursin(r"(?m)^\s*run:\s*julia --project=docs docs/make\.jl --deploy\s*$", docs_deploy_step)
     @test occursin("GITHUB_TOKEN", docs_deploy_step)
     @test !occursin("QCI_TOKEN", docs)
+    @test !isempty(docs_cleanup_delete_step)
+    @test occursin("id: cleanup", docs_cleanup_delete_step)
+    @test occursin("if [ ! -d \"previews/PR\$PRNUM\" ]; then", docs_cleanup_delete_step)
+    @test occursin("deleted=false", docs_cleanup_delete_step)
+    @test occursin("deleted=true", docs_cleanup_delete_step)
+    @test !isempty(docs_cleanup_push_step)
+    @test occursin("if: steps.cleanup.outputs.deleted == 'true'", docs_cleanup_push_step)
 
     dependabot = read(joinpath(@__DIR__, "..", ".github", "dependabot.yml"), String)
     @test occursin(r"package-ecosystem:\s*[\"']?github-actions[\"']?", dependabot)


### PR DESCRIPTION
## Summary

- Make docs preview cleanup a no-op when the expected `previews/PR<N>` directory is absent.
- Skip the force-push step when no preview directory was deleted.
- Add metadata regression checks for the cleanup guard and push-step condition.

## Context

This fixes the post-merge cleanup failure after PR #18:

`fatal: pathspec 'previews/PR18' did not match any files`

That failure is expected after no-deploy pull-request docs builds because there may be no preview directory to remove.

## Tests

- `julia --project=test --compiled-modules=no -e 'using Test; include("test/compat_metadata.jl")'` - passed: 41 tests.
- `julia --project=. --compiled-modules=no -e 'using Pkg; Pkg.test()'` - passed: 80 tests; live QCI tests skipped because `QCI_RUN_LIVE_TESTS` was not enabled.
- `git diff --check` - passed.
