### PR TITLE
Add docs Project compat bounds

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -4,3 +4,7 @@ updates:
     directory: "/"
     schedule:
       interval: "monthly"
+  - package-ecosystem: "julia"
+    directory: "/docs"
+    schedule:
+      interval: "monthly"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -2,3 +2,9 @@
 Documenter = "e30172f5-a6a5-5a46-863b-614d45cd2de4"
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 QCIOpt = "6e1d72ef-e149-4f5c-9c69-bc0273b92dbc"
+
+[compat]
+Documenter = "1"
+JuMP = "1.30"
+QCIOpt = "0.1"
+julia = "1.10"

--- a/docs/Project.toml
+++ b/docs/Project.toml
@@ -6,5 +6,6 @@ QCIOpt = "6e1d72ef-e149-4f5c-9c69-bc0273b92dbc"
 [compat]
 Documenter = "1"
 JuMP = "1.30"
+# Keep this aligned with the root Project.toml package version.
 QCIOpt = "0.1"
 julia = "1.10"


### PR DESCRIPTION
Summary
- Add docs compat bounds for Documenter, JuMP, QCIOpt, and Julia.
- Add a monthly Dependabot Julia update entry for `/docs`.

Tests
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=docs -e 'using Pkg; Pkg.resolve()'` passed with no changes.
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=docs docs/make.jl` passed without deployment.
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=. -e 'using Pkg; Pkg.test()'` passed: 107 tests, live QCI service tests skipped because `QCI_RUN_LIVE_TESTS` and `QCI_TOKEN` were not enabled.
- `ruby -e 'require "yaml"; YAML.load_file(".github/dependabot.yml")'` passed.
- `git diff --check` passed.

Notes
- The docs project has no direct Julia stdlib dependencies, so no stdlib compat entries were added.
- Julia is installed via juliaup in this environment; the `julia` shim is not on PATH, so verification used the Julia 1.10 launcher directly.

Closes #13
