### PR TITLE
Audit restrictive compat bounds

### DIFF
--- a/CondaPkg.toml
+++ b/CondaPkg.toml
@@ -4,7 +4,8 @@ channels = ["anaconda", "conda-forge"]
 python = ">=3.8,<=3.12"
 requests = ""
 
-# CondaPkg v0.2 does not support platform-scoped deps in this file.
+# CondaPkg is kept on the 0.2.x line because this environment file uses the
+# v0.2 dependency schema and does not support platform-scoped deps.
 # Keep libffi aligned with the Anaconda Python build to avoid Windows
 # PythonCall _ctypes initialization failures.
 [deps.libffi]

--- a/Project.toml
+++ b/Project.toml
@@ -14,10 +14,13 @@ PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
-CondaPkg = "=0.2.24"
-DynamicPolynomials = "0.6.1"
-JSON = "0.21.4"
-MathOptInterface = "1.35.2"
+# Keep CondaPkg on 0.2.x: CondaPkg.toml uses the v0.2 dependency schema and
+# the documented Anaconda libffi workaround for PythonCall on Windows.
+CondaPkg = "0.2.24"
+DynamicPolynomials = "0.6"
+JSON = "0.21, 1.6"
+MathOptInterface = "1"
+# PythonCall 0.9 owns the CondaPkg-backed Python environment used by qci-client.
 PythonCall = "0.9"
-Suppressor = "0.2.8"
+Suppressor = "0.2"
 julia = "1.10"

--- a/Project.toml
+++ b/Project.toml
@@ -19,7 +19,8 @@ Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 CondaPkg = "0.2.24"
 DynamicPolynomials = "0.6"
 JSON = "0.21, 1.6"
-MathOptInterface = "1"
+# Keep a tested MOI lower bound while allowing the 1.x line.
+MathOptInterface = "1.35"
 # PythonCall 0.9 owns the CondaPkg-backed Python environment used by qci-client.
 PythonCall = "0.9"
 Suppressor = "0.2"

--- a/src/QCIOpt.jl
+++ b/src/QCIOpt.jl
@@ -88,7 +88,17 @@ function jl_object(py_obj)
     # Convert Python object to JSON string, then parse it into a Julia object
     js_data = PythonCall.pyconvert(String, json.dumps(py_obj))
 
-    return JSON.parse(js_data)
+    return _plain_json_container(JSON.parse(js_data))
+end
+
+_plain_json_container(value) = value
+
+function _plain_json_container(value::AbstractDict)
+    return Dict{String,Any}(string(k) => _plain_json_container(v) for (k, v) in value)
+end
+
+function _plain_json_container(value::AbstractVector)
+    return Any[_plain_json_container(v) for v in value]
 end
 
 function py_object(jl_obj)

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -5,16 +5,52 @@ import Pkg
     project = TOML.parsefile(joinpath(@__DIR__, "..", "Project.toml"))
     docs_project = TOML.parsefile(joinpath(@__DIR__, "..", "docs", "Project.toml"))
     test_project = TOML.parsefile(joinpath(@__DIR__, "Project.toml"))
+    condapkg = TOML.parsefile(joinpath(@__DIR__, "..", "CondaPkg.toml"))
+    project_text = read(joinpath(@__DIR__, "..", "Project.toml"), String)
     compat = project["compat"]
+    deps = project["deps"]
 
     compat_allows_julia_110(compat_table, package) =
-        !haskey(compat_table, package) || v"1.10.0" in Pkg.Versions.VersionSpec(compat_table[package])
+        !haskey(compat_table, package) || v"1.10.0" in Pkg.Types.semver_spec(compat_table[package])
+
+    version_spec_allows(package, version) =
+        Pkg.Versions.VersionNumber(version) in Pkg.Types.semver_spec(compat[package])
 
     @test compat["julia"] == "1.10"
     @test compat_allows_julia_110(compat, "Dates")
     @test compat_allows_julia_110(compat, "LinearAlgebra")
     @test compat_allows_julia_110(Dict("LinearAlgebra" => "1"), "LinearAlgebra")
     @test !compat_allows_julia_110(Dict("LinearAlgebra" => "1.11.0"), "LinearAlgebra")
+
+    stdlib_deps = Set(["Dates", "LinearAlgebra"])
+    nonstdlib_deps = setdiff(Set(keys(deps)), stdlib_deps)
+    @test all(package -> haskey(compat, package), nonstdlib_deps)
+    @test all(package -> !startswith(compat[package], "="), nonstdlib_deps)
+
+    @test compat["CondaPkg"] == "0.2.24"
+    @test compat["DynamicPolynomials"] == "0.6"
+    @test compat["JSON"] == "0.21, 1.6"
+    @test compat["MathOptInterface"] == "1"
+    @test compat["PythonCall"] == "0.9"
+    @test compat["Suppressor"] == "0.2"
+    @test version_spec_allows("CondaPkg", "0.2.24")
+    @test version_spec_allows("CondaPkg", "0.2.36")
+    @test !version_spec_allows("CondaPkg", "0.3.0")
+    @test version_spec_allows("DynamicPolynomials", "0.6.6")
+    @test !version_spec_allows("DynamicPolynomials", "0.7.0")
+    @test version_spec_allows("JSON", "0.21.4")
+    @test version_spec_allows("JSON", "1.6.1")
+    @test !version_spec_allows("JSON", "1.5.2")
+    @test version_spec_allows("MathOptInterface", "1.51.1")
+    @test version_spec_allows("PythonCall", "0.9.34")
+    @test !version_spec_allows("PythonCall", "0.10.0")
+    @test version_spec_allows("Suppressor", "0.2.8")
+    @test occursin("Keep CondaPkg on 0.2.x", project_text)
+    @test occursin("PythonCall 0.9", project_text)
+    @test condapkg["deps"]["python"] == ">=3.8,<=3.12"
+    @test condapkg["deps"]["libffi"]["version"] == ">=3.4,<3.5"
+    @test condapkg["deps"]["libffi"]["channel"] == "anaconda"
+    @test condapkg["pip"]["deps"]["qci-client"] == ">=4.5"
 
     workflow_dir = joinpath(@__DIR__, "..", ".github", "workflows")
     workflow_files =

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -30,7 +30,7 @@ import Pkg
     @test compat["CondaPkg"] == "0.2.24"
     @test compat["DynamicPolynomials"] == "0.6"
     @test compat["JSON"] == "0.21, 1.6"
-    @test compat["MathOptInterface"] == "1"
+    @test compat["MathOptInterface"] == "1.35"
     @test compat["PythonCall"] == "0.9"
     @test compat["Suppressor"] == "0.2"
     @test version_spec_allows("CondaPkg", "0.2.24")
@@ -41,7 +41,9 @@ import Pkg
     @test version_spec_allows("JSON", "0.21.4")
     @test version_spec_allows("JSON", "1.6.1")
     @test !version_spec_allows("JSON", "1.5.2")
+    @test version_spec_allows("MathOptInterface", "1.35.0")
     @test version_spec_allows("MathOptInterface", "1.51.1")
+    @test !version_spec_allows("MathOptInterface", "1.34.0")
     @test version_spec_allows("PythonCall", "0.9.34")
     @test !version_spec_allows("PythonCall", "0.10.0")
     @test version_spec_allows("Suppressor", "0.2.8")

--- a/test/review_regressions.jl
+++ b/test/review_regressions.jl
@@ -151,4 +151,26 @@
         @test err isa AssertionError
         @test occursin("only supports minimizing", sprint(showerror, err))
     end
+
+    @testset "JSON metadata conversion returns plain Julia containers" begin
+        py_metadata = QCIOpt.py_object(
+            Dict(
+                "job_info" => Dict(
+                    "id" => "job-123",
+                    "tags" => ["offline", "compat"],
+                ),
+                "results" => Dict(
+                    "energies" => [1.0, 2.0],
+                    "counts" => [3, 4],
+                ),
+            ),
+        )
+        metadata = QCIOpt.jl_object(py_metadata)
+
+        @test metadata isa Dict{String,Any}
+        @test metadata["job_info"] isa Dict{String,Any}
+        @test metadata["job_info"]["tags"] isa Vector{Any}
+        @test metadata["job_info"]["tags"] == ["offline", "compat"]
+        @test metadata["results"]["counts"] == [3, 4]
+    end
 end


### PR DESCRIPTION
Summary

- Widened restrictive root compat entries for normal Julia dependencies.
- Kept the Python stack on documented compatible lanes: CondaPkg 0.2.x from 0.2.24 onward and PythonCall 0.9.x.
- Normalized JSON-parsed Python metadata into plain Julia Dict/Vector containers so JSON 1.6 remains compatible.
- Added metadata and regression tests for compat policy, CondaPkg.toml constraints, and JSON conversion.

Tests

- `/home/bernalde/.julia/juliaup/julia-1.10.11+0.x64.linux.gnu/bin/julia --startup-file=no --project=test -e 'using Test; include("test/compat_metadata.jl")'`
- Julia 1.10.11 fresh resolve via temporary environment: `Pkg.activate(mktempdir()); Pkg.develop(path=pwd()); Pkg.resolve(); Pkg.status()`
- Julia 1.12.6 fresh resolve via temporary environment: `Pkg.activate(mktempdir()); Pkg.develop(path=pwd()); Pkg.resolve(); Pkg.status()`
- Julia 1.10.11 latest-compatible package test via temporary environment: `Pkg.test("QCIOpt"; coverage=false)` with JSON 1.6.1
- Julia 1.12.6 package test from repo source: `Pkg.test("QCIOpt"; coverage=false)`
- Julia 1.12.6 manifest-free latest-compatible package test from a temporary source copy: `Pkg.test("QCIOpt"; coverage=false)` with JSON 1.6.1
- `git diff --check`

Closes #11
