### PR TITLE
Document URL-only release workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,26 @@ julia> import Pkg
 julia> Pkg.add(url="https://github.com/SECQUOIA/QCIOpt.jl")
 ```
 
+## Release Workflow
+
+QCIOpt.jl is currently a URL-only package. It is not registered in the Julia
+General registry, and this repository does not use TagBot or registry-based
+release automation. Install from the repository URL until the project explicitly
+chooses registry distribution.
+
+`Project.toml` is the source of truth for the package version. Dependabot and
+compatibility-only PRs are maintenance changes; they are not release-significant
+unless a maintainer intentionally includes a version bump and release work.
+
+Manual release checklist:
+
+- Bump `version` in `Project.toml`.
+- Run package tests with `julia --project=. -e 'using Pkg; Pkg.test()'`.
+- Build docs without deployment with `julia --project=docs docs/make.jl`.
+- Create an annotated tag matching the package version, for example
+  `git tag -a v0.1.0 -m "QCIOpt v0.1.0"`.
+- Push the release commit and tag after review.
+
 ## Basic Usage
 ```julia
 using JuMP

--- a/README.md
+++ b/README.md
@@ -26,9 +26,11 @@ Manual release checklist:
 
 - Bump `version` in `Project.toml`.
 - Run package tests with `julia --project=. -e 'using Pkg; Pkg.test()'`.
+- Prepare the docs environment with
+  `julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'`.
 - Build docs without deployment with `julia --project=docs docs/make.jl`.
 - Create an annotated tag matching the package version, for example
-  `git tag -a v0.1.0 -m "QCIOpt v0.1.0"`.
+  `git tag -a v<version> -m "QCIOpt v<version>"`.
 - Push the release commit and tag after review.
 
 ## Basic Usage

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -19,7 +19,7 @@ import Pkg
         Pkg.Versions.VersionNumber(version) in Pkg.Types.semver_spec(compat[package])
 
     @test compat["julia"] == "1.10"
-    @test project["version"] == "0.1.0"
+    @test VersionNumber(project["version"]) isa VersionNumber
     @test compat_allows_julia_110(compat, "Dates")
     @test compat_allows_julia_110(compat, "LinearAlgebra")
     @test compat_allows_julia_110(Dict("LinearAlgebra" => "1"), "LinearAlgebra")
@@ -64,8 +64,12 @@ import Pkg
     @test occursin("Dependabot and compatibility-only PRs are maintenance changes", readme_words)
     @test occursin("- Bump `version` in `Project.toml`.", readme_text)
     @test occursin("julia --project=. -e 'using Pkg; Pkg.test()'", readme_text)
+    @test occursin(
+        "julia --project=docs -e 'using Pkg; Pkg.develop(path=pwd()); Pkg.instantiate()'",
+        readme_text,
+    )
     @test occursin("julia --project=docs docs/make.jl", readme_text)
-    @test occursin("git tag -a v$(project["version"])", readme_text)
+    @test occursin("git tag -a v<version>", readme_text)
 
     workflow_dir = joinpath(@__DIR__, "..", ".github", "workflows")
     workflow_files =

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -7,6 +7,8 @@ import Pkg
     test_project = TOML.parsefile(joinpath(@__DIR__, "Project.toml"))
     condapkg = TOML.parsefile(joinpath(@__DIR__, "..", "CondaPkg.toml"))
     project_text = read(joinpath(@__DIR__, "..", "Project.toml"), String)
+    readme_text = read(joinpath(@__DIR__, "..", "README.md"), String)
+    readme_words = replace(readme_text, r"\s+" => " ")
     compat = project["compat"]
     deps = project["deps"]
 
@@ -17,6 +19,7 @@ import Pkg
         Pkg.Versions.VersionNumber(version) in Pkg.Types.semver_spec(compat[package])
 
     @test compat["julia"] == "1.10"
+    @test project["version"] == "0.1.0"
     @test compat_allows_julia_110(compat, "Dates")
     @test compat_allows_julia_110(compat, "LinearAlgebra")
     @test compat_allows_julia_110(Dict("LinearAlgebra" => "1"), "LinearAlgebra")
@@ -53,6 +56,16 @@ import Pkg
     @test condapkg["deps"]["libffi"]["version"] == ">=3.4,<3.5"
     @test condapkg["deps"]["libffi"]["channel"] == "anaconda"
     @test condapkg["pip"]["deps"]["qci-client"] == ">=4.5"
+    @test occursin("Pkg.add(url=\"https://github.com/SECQUOIA/QCIOpt.jl\")", readme_text)
+    @test occursin("QCIOpt.jl is currently a URL-only package", readme_words)
+    @test occursin("not registered in the Julia General registry", readme_words)
+    @test occursin("does not use TagBot or registry-based release automation", readme_words)
+    @test occursin("source of truth for the package version", readme_words)
+    @test occursin("Dependabot and compatibility-only PRs are maintenance changes", readme_words)
+    @test occursin("- Bump `version` in `Project.toml`.", readme_text)
+    @test occursin("julia --project=. -e 'using Pkg; Pkg.test()'", readme_text)
+    @test occursin("julia --project=docs docs/make.jl", readme_text)
+    @test occursin("git tag -a v$(project["version"])", readme_text)
 
     workflow_dir = joinpath(@__DIR__, "..", ".github", "workflows")
     workflow_files =
@@ -101,7 +114,11 @@ import Pkg
     @test occursin("uses: julia-actions/setup-julia@v3", docs)
     @test occursin("uses: julia-actions/julia-buildpkg@v1", docs)
     @test occursin("uses: actions/checkout@v6", docscleanup)
+    @test !any(file -> occursin("tagbot", lowercase(file)), workflow_files)
     @test !occursin("@latest", all_workflows)
+    @test !occursin("TagBot", all_workflows)
+    @test !occursin("JuliaRegistrator", all_workflows)
+    @test !occursin("JuliaRegistries/RegisterAction", all_workflows)
     @test !occursin("actions/checkout@v2", all_workflows)
     @test !occursin("julia-actions/setup-julia@v1", all_workflows)
 


### PR DESCRIPTION
Summary:
- Document that QCIOpt.jl remains URL-only for now, with no General registry registration, TagBot, or registry automation.
- Add a manual release checklist covering version bumps, package tests, docs builds, annotated tags, and pushing the release commit/tag.
- Extend metadata regression tests to lock the URL-only release policy, current `Project.toml` version, checklist text, and absence of registration workflows.

Tests:
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=test -e 'using Test; include("test/compat_metadata.jl")'` - passed, 101 tests.
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=. -e 'using Pkg; Pkg.test()'` - passed, 172 tests. Live QCI tests skipped because `QCI_RUN_LIVE_TESTS` was not set.
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=docs -e 'using Pkg; Pkg.develop(path=pwd())'` - passed, no changes.
- `/home/bernalde/.juliaup/bin/julialauncher +1.10 --project=docs docs/make.jl` - passed; Documenter reported existing missing-docstring warnings and skipped deployment.

Closes #10
