### PR TITLE
Add QUBODrivers DIRAC sampler

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -11,6 +11,8 @@ JSON = "682c06a0-de6a-54ab-a142-c8b1cf79cde6"
 LinearAlgebra = "37e2e46d-f89d-539d-b4ee-838fcccc9c8e"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 PythonCall = "6099a3de-0909-46bc-b1f4-468b9a2dfc0d"
+QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
+QUBOTools = "60eb5b62-0a39-4ddc-84c5-97d2adff9319"
 Suppressor = "fd094767-a336-5f1f-9728-57cf17d0bbfb"
 
 [compat]
@@ -23,5 +25,7 @@ JSON = "0.21, 1.6"
 MathOptInterface = "1.35"
 # PythonCall 0.9 owns the CondaPkg-backed Python environment used by qci-client.
 PythonCall = "0.9"
+QUBODrivers = "0.6"
+QUBOTools = "0.13"
 Suppressor = "0.2"
 julia = "1.10"

--- a/src/QCIOpt.jl
+++ b/src/QCIOpt.jl
@@ -128,4 +128,7 @@ include("devices/dirac1.jl")
 # include("devices/dirac2.jl")
 include("devices/dirac3.jl")
 
+# QUBODrivers sampler interface
+include("samplers/dirac.jl")
+
 end # module QCIOpt

--- a/src/devices/dirac1.jl
+++ b/src/devices/dirac1.jl
@@ -155,11 +155,13 @@ function qci_optimize!(solver::Optimizer{T}, device::DIRAC_1{T}, model::MOI.Mode
     silent      = MOI.get(solver, MOI.Silent())
     file_name   = MOI.get(solver, MOI.RawOptimizerAttribute("file_name"))
     num_samples = MOI.get(solver, MOI.RawOptimizerAttribute("num_samples"))
+    relaxation_schedule = MOI.get(solver, MOI.RawOptimizerAttribute("relaxation_schedule"))
 
     job_params = Dict{Symbol,Any}(
-        :device_type => "dirac-1",
-        :job_type    => "sample-qubo",
-        :num_samples => num_samples,
+        :device_type         => "dirac-1",
+        :job_type            => "sample-qubo",
+        :num_samples         => num_samples,
+        :relaxation_schedule => relaxation_schedule,
     )
 
     file     = qci_data_file(device.matrix; file_name)
@@ -206,12 +208,14 @@ function qci_build_job_body(
     # Job Arguments
     device_type::AbstractString = "dirac-1",
     job_type::AbstractString    = "sample-qubo",
-    num_samples::Integer        = 100,
+    num_samples::Integer         = 100,
+    relaxation_schedule::Integer = 1,
 ) where {T}
     job_tags   = String[]
     job_params = Dict{String,Any}(
-        "device_type" => device_type,
-        "num_samples" => num_samples,
+        "device_type"         => device_type,
+        "num_samples"         => num_samples,
+        "relaxation_schedule" => relaxation_schedule,
     )
 
     return qci_client(; url, api_token, silent) do client

--- a/src/samplers/dirac.jl
+++ b/src/samplers/dirac.jl
@@ -1,0 +1,327 @@
+module DiracSampler
+
+import ..QCIOpt
+import QUBODrivers
+import QUBODrivers: MOI, QUBOTools, Sample, SampleSet
+
+const DEFAULT_DEVICE_TYPE = "dirac-1"
+const DEFAULT_JOB_TYPE = "sample-qubo"
+
+function qci_client_version()
+    return try
+        QCIOpt.PythonCall.pyconvert(
+            String,
+            QCIOpt.PythonCall.pyimport("importlib.metadata").version("qci-client"),
+        )
+    catch
+        nothing
+    end
+end
+
+function _get_path(value, path::Tuple)
+    current = value
+
+    for key in path
+        if current isa AbstractDict && haskey(current, key)
+            current = current[key]
+        else
+            return nothing
+        end
+    end
+
+    return current
+end
+
+function _backend_value(result, key::String, default = nothing)
+    if result isa AbstractDict
+        return get(result, key, default)
+    elseif result isa NamedTuple && key in string.(keys(result))
+        return getproperty(result, Symbol(key))
+    else
+        return default
+    end
+end
+
+function _duration_seconds(metrics, path_start::Tuple, path_end::Tuple)
+    start_ns = _get_path(metrics, path_start)
+    end_ns = _get_path(metrics, path_end)
+
+    if start_ns isa Real && end_ns isa Real && end_ns >= start_ns
+        return (Float64(end_ns) - Float64(start_ns)) / 1e9
+    else
+        return nothing
+    end
+end
+
+function effective_time(response, metrics; device_type::AbstractString = DEFAULT_DEVICE_TYPE)
+    runtime = _get_path(
+        metrics,
+        ("job_metrics", "time_ns", "device", device_type, "samples", "runtime"),
+    )
+
+    if runtime isa AbstractVector && all(item -> item isa Real, runtime)
+        return sum(Float64, runtime) / 1e9
+    end
+
+    device_usage_s = _get_path(response, ("job_info", "job_result", "device_usage_s"))
+
+    if device_usage_s isa Real
+        return Float64(device_usage_s)
+    end
+
+    return 0.0
+end
+
+function termination_status(status)
+    status == "COMPLETED" && return MOI.LOCALLY_SOLVED
+    status == "CANCELLED" && return MOI.INTERRUPTED
+    status == "ERRORED" && return MOI.OTHER_ERROR
+
+    return MOI.OTHER_ERROR
+end
+
+function qci_qubo_matrix(
+    ::Type{T},
+    n::Integer,
+    linear::AbstractDict,
+    quadratic::AbstractDict,
+    scale::Real,
+) where {T}
+    matrix = zeros(T, n, n)
+    factor = convert(T, scale)
+
+    for (i, coefficient) in linear
+        matrix[Int(i), Int(i)] += factor * convert(T, coefficient)
+    end
+
+    for ((i, j), coefficient) in quadratic
+        value = factor * convert(T, coefficient)
+        row = Int(i)
+        col = Int(j)
+
+        if row == col
+            matrix[row, col] += value
+        else
+            matrix[row, col] += value / 2
+            matrix[col, row] += value / 2
+        end
+    end
+
+    return matrix
+end
+
+function default_backend_runner(
+    matrix::AbstractMatrix{T};
+    api_token::AbstractString,
+    num_samples::Integer,
+    relaxation_schedule::Integer = 1,
+    silent::Bool = false,
+) where {T}
+    device = QCIOpt.DIRAC_1{T}()
+    file = QCIOpt.qci_data_file(matrix)
+    file_id = QCIOpt.qci_upload_file(file; api_token, silent)
+    job_body = QCIOpt.qci_build_job_body(
+        device;
+        file_id,
+        api_token,
+        silent,
+        device_type = DEFAULT_DEVICE_TYPE,
+        job_type = DEFAULT_JOB_TYPE,
+        num_samples,
+        relaxation_schedule,
+    )
+    response = QCIOpt.qci_process_job(job_body; api_token, verbose = !silent)
+    job_id = _get_path(response, ("job_info", "job_id"))
+
+    metrics = if job_id isa AbstractString
+        try
+            QCIOpt.qci_client(; api_token, silent = true) do client
+                return client.get_job_metrics(; job_id) |> QCIOpt.jl_object
+            end
+        catch err
+            Dict{String,Any}(
+                "capture_error_type" => string(typeof(err)),
+                "capture_error" => sprint(showerror, err),
+            )
+        end
+    else
+        nothing
+    end
+
+    return Dict{String,Any}(
+        "response" => response,
+        "metrics" => metrics,
+        "qci_client_version" => qci_client_version(),
+        "request" => Dict{String,Any}(
+            "file_id" => file_id,
+            "num_samples" => num_samples,
+            "relaxation_schedule" => relaxation_schedule,
+        ),
+    )
+end
+
+@doc raw"""
+    QCIOpt.DiracSampler.Optimizer{T}
+
+QUBODrivers sampler interface for QCI DIRAC-1 QUBO sampling.
+
+This sampler is additive to `QCIOpt.Optimizer`: the existing MOI wrapper remains
+available for the broader QCI device interface, while this type exposes the
+uniform QUBODrivers sampler contract used by benchmark harnesses.
+"""
+QUBODrivers.@setup Optimizer begin
+    name = "QCI Dirac"
+    version = v"0.1.0"
+    attributes = begin
+        NumberOfSamples["num_samples"]::Integer = 10
+        DeviceType["device_type"]::String = DEFAULT_DEVICE_TYPE
+        RelaxationSchedule["relaxation_schedule"]::Integer = 1
+        APIToken["api_token"]::Union{String,Nothing} = nothing
+        Silent["silent"]::Bool = false
+        BackendRunner["backend_runner"]::Function = default_backend_runner
+    end
+end
+
+function QUBODrivers.sample(sampler::Optimizer{T}) where {T}
+    n, linear, quadratic, scale, offset = QUBOTools.qubo(sampler, :dict; sense = :min)
+
+    num_samples = MOI.get(sampler, NumberOfSamples())
+    final_num_samples = MOI.get(sampler, QUBODrivers.FinalNumberOfReads())
+    device_type = MOI.get(sampler, DeviceType())
+    relaxation_schedule = MOI.get(sampler, RelaxationSchedule())
+    api_token = MOI.get(sampler, APIToken())
+    silent = MOI.get(sampler, Silent())
+    runner = MOI.get(sampler, BackendRunner())
+
+    final_num_samples = isnothing(final_num_samples) ? num_samples : final_num_samples
+
+    num_samples >= 1 || error("'num_samples' must be a positive integer")
+    final_num_samples >= 1 || error("'final_num_reads' must be a positive integer")
+    device_type == DEFAULT_DEVICE_TYPE || error("QCI Dirac sampler only supports 'dirac-1'")
+
+    if isnothing(api_token)
+        api_token = QCIOpt.qci_default_token()
+    end
+
+    isnothing(api_token) && error("QCI API Token is not defined.")
+
+    matrix = qci_qubo_matrix(T, n, linear, quadratic, scale)
+    backend = runner(
+        matrix;
+        api_token,
+        num_samples = final_num_samples,
+        relaxation_schedule,
+        silent,
+    )
+    response = _backend_value(backend, "response")
+    metrics = _backend_value(backend, "metrics")
+    backend_version = _backend_value(backend, "qci_client_version", qci_client_version())
+    request = _backend_value(backend, "request", Dict{String,Any}())
+
+    samples = samples_from_response(T, response, linear, quadratic, scale, offset)
+    metadata = metadata_from_response(
+        response,
+        metrics,
+        request;
+        backend_version,
+        num_samples = sum(QUBOTools.reads(sample) for sample in samples),
+        device_type,
+    )
+
+    return SampleSet{T}(samples, metadata; sense = :min, domain = :bool)
+end
+
+function samples_from_response(
+    ::Type{T},
+    response,
+    linear::AbstractDict,
+    quadratic::AbstractDict,
+    scale::Real,
+    offset::Real,
+) where {T}
+    results = response["results"]
+    solutions = results["solutions"]
+    counts = results["counts"]
+    samples = Vector{Sample{T,Int}}(undef, length(solutions))
+
+    for i in eachindex(solutions)
+        state = round.(Int, solutions[i])
+        value = convert(T, QUBOTools.value(state, linear, quadratic, scale, offset))
+        reads = Int(counts[i])
+
+        samples[i] = Sample{T,Int}(state, value, reads)
+    end
+
+    return samples
+end
+
+function metadata_from_response(
+    response,
+    metrics,
+    request;
+    backend_version,
+    num_samples::Integer,
+    device_type::AbstractString = DEFAULT_DEVICE_TYPE,
+)
+    status = response["status"]
+    job_info = response["job_info"]
+    job_status = get(job_info, "job_status", Dict{String,Any}())
+    job_result = get(job_info, "job_result", Dict{String,Any}())
+    job_submission = get(job_info, "job_submission", Dict{String,Any}())
+    qubo_config = _get_path(
+        job_info,
+        ("job_submission", "problem_config", "quadratic_unconstrained_binary_optimization"),
+    )
+    problem_file_id = qubo_config isa AbstractDict ? get(qubo_config, "qubo_file_id", nothing) : nothing
+
+    metadata = QUBODrivers._sampler_metadata(
+        origin = "QCI Dirac @ qci-client",
+        algorithm_name = "QCI Dirac",
+        backend_name = "QCI Dirac",
+        backend_version = backend_version,
+        execution_mode = "cloud_sampling",
+        optimizer_iterations = nothing,
+        optimizer_evaluations = num_samples,
+        number_of_reads = num_samples,
+        final_number_of_reads = num_samples,
+        status = status,
+        termination_status = termination_status(status),
+    )
+
+    metadata["backend"]["device"] = device_type
+    metadata["backend"]["job_id"] = get(job_info, "job_id", nothing)
+    metadata["backend"]["result_file_id"] = get(job_result, "file_id", nothing)
+    metadata["backend"]["problem_file_id"] = problem_file_id
+    metadata["time"] = Dict{String,Any}(
+        "effective" => effective_time(response, metrics; device_type),
+        "provider_wall" => _duration_seconds(
+            metrics,
+            ("job_metrics", "time_ns", "wall", "start"),
+            ("job_metrics", "time_ns", "wall", "end"),
+        ),
+        "provider_queue" => _duration_seconds(
+            metrics,
+            ("job_metrics", "time_ns", "wall", "queue", "start"),
+            ("job_metrics", "time_ns", "wall", "queue", "end"),
+        ),
+        "provider_processing" => _duration_seconds(
+            metrics,
+            ("job_metrics", "time_ns", "wall", "processing", "start"),
+            ("job_metrics", "time_ns", "wall", "processing", "end"),
+        ),
+        "device_usage" => get(job_result, "device_usage_s", nothing),
+    )
+    metadata["provider"] = Dict{String,Any}(
+        "job_info" => job_info,
+        "job_status" => job_status,
+        "job_result" => job_result,
+        "job_submission" => job_submission,
+        "metrics" => metrics,
+        "request" => request,
+        "qci_client_version" => backend_version,
+    )
+
+    return metadata
+end
+
+end # module

--- a/test/Project.toml
+++ b/test/Project.toml
@@ -2,5 +2,6 @@
 JuMP = "4076af6c-e467-56ae-b986-b466b2749572"
 MathOptInterface = "b8f27783-ece8-5eb3-8dc8-9495eed66fee"
 Pkg = "44cfe95a-1eb2-52ea-b672-e2afdf69b78f"
+QUBODrivers = "a3f166f7-2cd3-47b6-9e1e-6fbfe0449eb0"
 TOML = "fa267f1f-6049-4f14-aa54-33bafae1ed76"
 Test = "8dfed614-e22c-5e08-85e1-65c5234f0b40"

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -35,6 +35,8 @@ import Pkg
     @test compat["JSON"] == "0.21, 1.6"
     @test compat["MathOptInterface"] == "1.35"
     @test compat["PythonCall"] == "0.9"
+    @test compat["QUBODrivers"] == "0.6"
+    @test compat["QUBOTools"] == "0.13"
     @test compat["Suppressor"] == "0.2"
     @test version_spec_allows("CondaPkg", "0.2.24")
     @test version_spec_allows("CondaPkg", "0.2.36")
@@ -49,6 +51,10 @@ import Pkg
     @test !version_spec_allows("MathOptInterface", "1.34.0")
     @test version_spec_allows("PythonCall", "0.9.34")
     @test !version_spec_allows("PythonCall", "0.10.0")
+    @test version_spec_allows("QUBODrivers", "0.6.1")
+    @test !version_spec_allows("QUBODrivers", "0.7.0")
+    @test version_spec_allows("QUBOTools", "0.13.1")
+    @test !version_spec_allows("QUBOTools", "0.14.0")
     @test version_spec_allows("Suppressor", "0.2.8")
     @test occursin("Keep CondaPkg on 0.2.x", project_text)
     @test occursin("PythonCall 0.9", project_text)

--- a/test/qubodrivers_sampler.jl
+++ b/test/qubodrivers_sampler.jl
@@ -1,0 +1,153 @@
+import QUBODrivers
+import QUBODrivers: QUBOTools
+
+@testset "QUBODrivers DIRAC sampler" begin
+    @testset "Attributes and QCI matrix conversion" begin
+        sampler = QCIOpt.DiracSampler.Optimizer()
+
+        @test MOI.get(sampler, MOI.SolverName()) == "QCI Dirac"
+        @test MOI.get(sampler, QCIOpt.DiracSampler.NumberOfSamples()) == 10
+        @test MOI.get(sampler, QCIOpt.DiracSampler.DeviceType()) == "dirac-1"
+        @test !QUBODrivers.supports_seed(sampler)
+
+        linear = Dict(1 => 1.0, 2 => 1.0)
+        quadratic = Dict((1, 2) => -2.0)
+
+        @test QCIOpt.DiracSampler.qci_qubo_matrix(Float64, 2, linear, quadratic, 1.0) ==
+            [1.0 -1.0; -1.0 1.0]
+    end
+
+    @testset "Mocked sampler produces benchmark metadata" begin
+        model = MOI.Utilities.Model{Float64}()
+        x = MOI.add_variables(model, 2)
+
+        MOI.add_constraint(model, x[1], MOI.ZeroOne())
+        MOI.add_constraint(model, x[2], MOI.ZeroOne())
+
+        f = MOI.ScalarQuadraticFunction(
+            [MOI.ScalarQuadraticTerm(-2.0, x[1], x[2])],
+            [MOI.ScalarAffineTerm(1.0, x[1]), MOI.ScalarAffineTerm(1.0, x[2])],
+            1.0,
+        )
+
+        MOI.set(model, MOI.ObjectiveSense(), MOI.MIN_SENSE)
+        MOI.set(model, MOI.ObjectiveFunction{typeof(f)}(), f)
+
+        captured_matrix = Ref{Matrix{Float64}}()
+
+        mock_runner = function (
+            matrix;
+            api_token,
+            num_samples,
+            relaxation_schedule,
+            silent,
+        )
+            captured_matrix[] = copy(matrix)
+
+            @test api_token == "dummy-token"
+            @test num_samples == 5
+            @test relaxation_schedule == 1
+            @test silent
+
+            return Dict{String,Any}(
+                "response" => Dict{String,Any}(
+                    "status" => "COMPLETED",
+                    "results" => Dict{String,Any}(
+                        "solutions" => [[0, 0], [0, 1], [1, 1]],
+                        "energies" => [1.0, 2.0, 1.0],
+                        "counts" => [1, 2, 2],
+                    ),
+                    "job_info" => Dict{String,Any}(
+                        "job_id" => "job-123",
+                        "job_result" => Dict{String,Any}(
+                            "device_usage_s" => 2,
+                            "file_id" => "result-file-123",
+                        ),
+                        "job_status" => Dict{String,Any}(
+                            "submitted_at_rfc3339nano" => "2026-06-14T10:11:37.359Z",
+                            "queued_at_rfc3339nano" => "2026-06-14T10:11:37.360Z",
+                            "running_at_rfc3339nano" => "2026-06-14T10:11:37.879Z",
+                            "completed_at_rfc3339nano" => "2026-06-14T10:13:51.189Z",
+                        ),
+                        "job_submission" => Dict{String,Any}(
+                            "problem_config" => Dict{String,Any}(
+                                "quadratic_unconstrained_binary_optimization" =>
+                                    Dict{String,Any}("qubo_file_id" => "qubo-file-123"),
+                            ),
+                        ),
+                    ),
+                ),
+                "metrics" => Dict{String,Any}(
+                    "job_id" => "job-123",
+                    "job_metrics" => Dict{String,Any}(
+                        "time_ns" => Dict{String,Any}(
+                            "device" => Dict{String,Any}(
+                                "dirac-1" => Dict{String,Any}(
+                                    "samples" => Dict{String,Any}(
+                                        "runtime" => [
+                                            100_000_000,
+                                            200_000_000,
+                                            300_000_000,
+                                            400_000_000,
+                                            500_000_000,
+                                        ],
+                                    ),
+                                ),
+                            ),
+                            "wall" => Dict{String,Any}(
+                                "start" => 1_000_000_000,
+                                "end" => 4_000_000_000,
+                                "queue" => Dict{String,Any}(
+                                    "start" => 1_000_000_000,
+                                    "end" => 1_500_000_000,
+                                ),
+                                "processing" => Dict{String,Any}(
+                                    "start" => 1_500_000_000,
+                                    "end" => 4_000_000_000,
+                                ),
+                            ),
+                        ),
+                    ),
+                ),
+                "qci_client_version" => "5.0.0",
+                "request" => Dict{String,Any}("num_samples" => num_samples),
+            )
+        end
+
+        sampler = QCIOpt.DiracSampler.Optimizer{Float64}()
+
+        MOI.set(sampler, QCIOpt.DiracSampler.APIToken(), "dummy-token")
+        MOI.set(sampler, QCIOpt.DiracSampler.NumberOfSamples(), 5)
+        MOI.set(sampler, QCIOpt.DiracSampler.Silent(), true)
+        MOI.set(sampler, QCIOpt.DiracSampler.BackendRunner(), mock_runner)
+
+        MOI.copy_to(sampler, model)
+        MOI.optimize!(sampler)
+
+        @test captured_matrix[] == [1.0 -1.0; -1.0 1.0]
+        @test MOI.get(sampler, MOI.ResultCount()) == 3
+        @test MOI.get(sampler, MOI.RawStatusString()) == "COMPLETED"
+        @test MOI.get(sampler, MOI.TerminationStatus()) == MOI.LOCALLY_SOLVED
+        @test MOI.get(sampler, MOI.SolveTimeSec()) ≈ 1.5
+        @test MOI.get(sampler, MOI.ObjectiveValue(1)) ≈ 1.0
+
+        metadata = QUBOTools.metadata(QUBOTools.solution(sampler))
+
+        @test isempty(QUBODrivers.validate_metadata(metadata))
+        @test metadata["backend"]["name"] == "QCI Dirac"
+        @test metadata["backend"]["version"] == "5.0.0"
+        @test metadata["backend"]["device"] == "dirac-1"
+        @test metadata["backend"]["job_id"] == "job-123"
+        @test metadata["backend"]["result_file_id"] == "result-file-123"
+        @test metadata["backend"]["problem_file_id"] == "qubo-file-123"
+        @test metadata["reads"]["number_of_reads"] == 5
+        @test metadata["reads"]["final_number_of_reads"] == 5
+        @test metadata["time"]["effective"] ≈ 1.5
+        @test metadata["time"]["provider_wall"] ≈ 3.0
+        @test metadata["time"]["provider_queue"] ≈ 0.5
+        @test metadata["time"]["provider_processing"] ≈ 2.5
+        @test metadata["time"]["device_usage"] == 2
+        @test metadata["provider"]["metrics"]["job_id"] == "job-123"
+        @test metadata["provider"]["qci_client_version"] == "5.0.0"
+    end
+end

--- a/test/runtests.jl
+++ b/test/runtests.jl
@@ -9,6 +9,7 @@ import MathOptInterface as MOI
     include("compat_metadata.jl")
     include("auth.jl")
     include("offline.jl")
+    include("qubodrivers_sampler.jl")
     include("review_regressions.jl")
 
     if lowercase(get(ENV, "QCI_RUN_LIVE_TESTS", "false")) in ("1", "true", "yes")


### PR DESCRIPTION
## Summary

- Adds an additive `QCIOpt.DiracSampler.Optimizer` implemented with `QUBODrivers.@setup` for DIRAC-1 QUBO sampling.
- Converts QUBODrivers/QUBOTools QUBO data into the symmetric QCI matrix format and delegates live submissions through the existing QCI client helpers.
- Preserves standardized benchmark metadata plus provider diagnostics: job id, status, result/problem file ids, qci-client version, job_info, request data, and `get_job_metrics` output when available.
- Uses device sample runtime metrics for `metadata["time"]["effective"]`, falling back to `job_result.device_usage_s`.
- Forwards DIRAC-1 `relaxation_schedule` into the existing device job body so the supported attribute reaches the provider.
- Adds offline mocked sampler coverage and dependency compatibility checks for QUBODrivers/QUBOTools.

Refs #25.

## Validation

- `julia --project=. -e 'using Pkg; Pkg.test()'`
  - Result: `233` tests passed.
  - Live QCI tests were skipped because `QCI_RUN_LIVE_TESTS` was not enabled locally.
- `git diff --check`
  - Result: passed.

## Notes

- This PR implements the issue's PR 2 checkpoint using the live DIRAC-1 field map posted on issue 25.
- It does not run the PR 3 QUBODrivers conformance suite or live full-metadata validation; those remain follow-up work.

## Branch Hygiene

- Base branch: `main`.
- Source branch point: `f0ae320edb7ac26c8edbbf952901768d288fb8b1` (`origin/main` at branch creation and before push).
- Stacked status: not stacked; this branch is based directly on `origin/main`.
- Prerequisite PRs: none.
