### PR TITLE
Widen QUBOTools compat to include 0.14

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -26,6 +26,6 @@ MathOptInterface = "1.35"
 # PythonCall 0.9 owns the CondaPkg-backed Python environment used by qci-client.
 PythonCall = "0.9"
 QUBODrivers = "0.6"
-QUBOTools = "0.13, 0.15"
+QUBOTools = "0.13, 0.14, 0.15"
 Suppressor = "0.2"
 julia = "1.10"

--- a/test/compat_metadata.jl
+++ b/test/compat_metadata.jl
@@ -48,6 +48,7 @@ import Pkg
     @test !version_spec_allows("PythonCall", "0.10.0")
     @test version_spec_allows("QUBODrivers", "0.6.1")
     @test version_spec_allows("QUBOTools", "0.13.1")
+    @test version_spec_allows("QUBOTools", "0.14.0")
     @test version_spec_allows("QUBOTools", "0.15.0")
     @test version_spec_allows("Suppressor", "0.2.8")
     @test occursin("Keep CondaPkg on 0.2.x", project_text)


### PR DESCRIPTION
## Summary

- Widen `QUBOTools` compat from `0.13, 0.15` to `0.13, 0.14, 0.15`.
- Add a semantic compat metadata assertion that `QUBOTools 0.14.0` is allowed.

Closes #28

## Verification

- `julia --project=. -e 'using Test; include("test/compat_metadata.jl")'`
  - Passed: 118 metadata assertions.
- Fresh temporary environment with `QUBOTools v0.14.4` pinned and `QUBODrivers v0.6.5` resolved:
  - `using QCIOpt; using QUBOTools`
  - `Pkg.test("QCIOpt")`
  - Passed: 430 tests. Live QCI service tests were skipped because they require `QCI_RUN_LIVE_TESTS=true` and `QCI_TOKEN`.
- Latest allowed resolver check resolved `QUBOTools v0.15.1` and `QUBODrivers v0.6.5`; `Pkg.test("QCIOpt")` passed 430 tests.

## Branch Hygiene

- Base branch: `main`
- Source branch point: `origin/main` at `95b83a4892577c07e480d7908dce8d45feefe82b`
- Head branch: `fix/issue-28-qubotools-014-compat`
- Stacked status: standalone; no prerequisite PRs.
